### PR TITLE
feat: custom dir on fs storage

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,17 @@
-const fs = require('fs').promises
+const fs = require('fs')
+const promises = require('fs/promises')
 const os = require('os')
+const path = require('path')
 
 const writeData = async (data, fileName, config, s3Client) => {
     if (config.storage.type === 'fs') {
-        const tmpDir = os.tmpdir()
-        await fs.writeFile(`${tmpDir}/${fileName}`, JSON.stringify(data))
+        let pathDestination = os.tmpdir()
+        const customPath = config?.storage?.dir ?? ''
+        if (customPath && fs.existsSync(path.resolve(customPath))) {
+            pathDestination = customPath
+        }
+
+        await promises.writeFile(`${pathDestination}/${fileName}`, JSON.stringify(data))
     } else if (config.storage.type === 's3') {
         const { PutObjectCommand } = require('@aws-sdk/client-s3')
         const params = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,12 +5,12 @@ const path = require('path')
 
 const writeData = async (data, fileName, config, s3Client) => {
     if (config.storage.type === 'fs') {
-        let pathDestination = os.tmpdir()
-        const customPath = config.storage.dir || ''
-        if (customPath && fs.existsSync(path.resolve(customPath))) {
-            pathDestination = path.resolve(customPath)
+        let destDir = os.tmpdir()
+        const customDir = config.storage.dir || ''
+        if (customDir && fs.existsSync(path.resolve(customDir))) {
+            destDir = path.resolve(customDir)
         }
-        await promises.writeFile(`${pathDestination}/${fileName}`, JSON.stringify(data))
+        await promises.writeFile(`${destDir}/${fileName}`, JSON.stringify(data))
     } else if (config.storage.type === 's3') {
         const { PutObjectCommand } = require('@aws-sdk/client-s3')
         const params = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const promises = require('fs/promises')
+const fsPromises = require('fs').promises
 const os = require('os')
 const path = require('path')
 
@@ -10,7 +10,7 @@ const writeData = async (data, fileName, config, s3Client) => {
         if (customDir && fs.existsSync(path.resolve(customDir))) {
             destDir = path.resolve(customDir)
         }
-        await promises.writeFile(`${destDir}/${fileName}`, JSON.stringify(data))
+        await fsPromises.writeFile(`${destDir}/${fileName}`, JSON.stringify(data))
     } else if (config.storage.type === 's3') {
         const { PutObjectCommand } = require('@aws-sdk/client-s3')
         const params = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,9 +6,9 @@ const path = require('path')
 const writeData = async (data, fileName, config, s3Client) => {
     if (config.storage.type === 'fs') {
         let pathDestination = os.tmpdir()
-        const customPath = config?.storage?.dir ?? ''
+        const customPath = config.storage.dir || ''
         if (customPath && fs.existsSync(path.resolve(customPath))) {
-            pathDestination = customPath
+            pathDestination = path.resolve(customPath)
         }
         await promises.writeFile(`${pathDestination}/${fileName}`, JSON.stringify(data))
     } else if (config.storage.type === 's3') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,6 @@ const writeData = async (data, fileName, config, s3Client) => {
         if (customPath && fs.existsSync(path.resolve(customPath))) {
             pathDestination = customPath
         }
-
         await promises.writeFile(`${pathDestination}/${fileName}`, JSON.stringify(data))
     } else if (config.storage.type === 's3') {
         const { PutObjectCommand } = require('@aws-sdk/client-s3')


### PR DESCRIPTION
### Background
Currently for fs storage type will always store profiling result to `os.tmpdir()`. That is might be hard for beginner developers to find where is the tmpdir in the OS. And refer to the document, we have `storage.dir` as target custom directory, but currently this option only support for s3. So I think we need to adding `storage.dir` option to support for fs storage type.

e.g:
``` sh
const Inspector = require("inspector-api");

const inspector = new Inspector({
   storage: {
     type: "fs",
     dir: "./profile-results",
   },
});
```